### PR TITLE
src/ehc: partially fix ghc-7.6 compatibility

### DIFF
--- a/EHC/src/ehc/Base/Bits.chs
+++ b/EHC/src/ehc/Base/Bits.chs
@@ -15,10 +15,10 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %%[(8 codegen) export(entierLogUpShrBy,entierLogUpBy)
-entierLogUpShrBy :: Bits x => Int -> x -> x
+entierLogUpShrBy :: (Num x, Bits x) => Int -> x -> x
 entierLogUpShrBy by x = ((x - 1) `shiftR` by) + 1
 
-entierLogUpBy :: Bits x => Int -> x -> x
+entierLogUpBy :: (Num x, Bits x) => Int -> x -> x
 entierLogUpBy by x = entierLogUpShrBy by x `shiftL` by
 %%]
 
@@ -39,7 +39,7 @@ entierUpBy by x = entierUpShrBy by x * by
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %%[(8 codegen) export(pow2)
-pow2 :: Bits x => Int -> x
+pow2 :: (Num x, Bits x) => Int -> x
 pow2 x = 1 `shiftL` x
 
 pow2' :: Int -> (Integer,Integer,Integer)
@@ -69,7 +69,7 @@ pow2' x
 %%]
 
 %%[(8 codegen)
-mask2 :: Bits x => Int -> x
+mask2 :: (Num x, Bits x) => Int -> x
 mask2 x = pow2 x - 1
 %%]
 

--- a/EHC/src/ehc/CHR/Solve.chs
+++ b/EHC/src/ehc/CHR/Solve.chs
@@ -486,7 +486,8 @@ chrSolveStateTrace = stTrace
 
 %%[(9 hmtyinfer || hmtyast) export(chrSolve,chrSolve')
 chrSolve
-  :: ( CHRMatchable env p s, CHRCheckable env g s
+  :: ( Ord i, Ord p
+     , CHRMatchable env p s, CHRCheckable env g s
      -- , VarUpdatable s s, VarUpdatable g s, VarUpdatable i s, VarUpdatable p s
      , VarLookupCmb s s
      , VarUpdatable s s, VarUpdatable g s, VarUpdatable i s, VarUpdatable p s
@@ -506,7 +507,8 @@ chrSolve env chrStore cnstrs
   where (work,done,_) = chrSolve' env chrStore cnstrs
 
 chrSolve'
-  :: ( CHRMatchable env p s, CHRCheckable env g s
+  :: ( Ord i, Ord p
+     , CHRMatchable env p s, CHRCheckable env g s
      -- , VarUpdatable s s, VarUpdatable g s, VarUpdatable i s, VarUpdatable p s
      , VarLookupCmb s s
      , VarUpdatable s s, VarUpdatable g s, VarUpdatable i s, VarUpdatable p s
@@ -529,7 +531,8 @@ chrSolve' env chrStore cnstrs
 %%[(9 hmtyinfer || hmtyast) export(chrSolve'')
 chrSolve''
   :: forall env p i g s .
-     ( CHRMatchable env p s, CHRCheckable env g s
+     ( Ord i, Ord p
+     , CHRMatchable env p s, CHRCheckable env g s
      -- , VarUpdatable s s, VarUpdatable g s, VarUpdatable i s, VarUpdatable p s
      , VarLookupCmb s s
      , VarUpdatable s s, VarUpdatable g s, VarUpdatable i s, VarUpdatable p s


### PR DESCRIPTION
Added missing Ord and Num instances.

Sample failure:

src/ehc/CHR/Solve.chs:518:22:
    Could not deduce (Ord i) arising from a use of chrSolve''
    from the context (CHRMatchable env p s,
                      CHRCheckable env g s,
                      VarLookupCmb s s,
                      VarUpdatable s s,
                      VarUpdatable g s,
                      VarUpdatable i s,
                      VarUpdatable p s,
                      CHREmptySubstitution s,
                      Ord (Constraint p i))

Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
