### PR TITLE
src/ehc: port to hashable-1.2

### DIFF
--- a/EHC/configure
+++ b/EHC/configure
@@ -3798,7 +3798,7 @@ HADDOCK_VERSION=$haddockVersion
 
 
 # GHC version dependencies: packages passed as option, cabal packages
-cabal_base_lib_depends="base mtl fgl directory hashable>=1.1&&<1.2 uhc-util>=0.1.1"
+cabal_base_lib_depends="base mtl fgl directory hashable>=1.2&&<1.3 uhc-util>=0.1.1"
 if test x$enableClr = "xyes"
 then
   cabal_base_lib_depends="$cabal_base_lib_depends language-cil"

--- a/EHC/configure.ac
+++ b/EHC/configure.ac
@@ -415,7 +415,7 @@ AC_SUBST(HADDOCK_CMD,$haddockCmd)
 AC_SUBST(HADDOCK_VERSION, $haddockVersion)
 
 # GHC version dependencies: packages passed as option, cabal packages
-cabal_base_lib_depends="base mtl fgl directory hashable>=1.1&&<1.2 uhc-util>=0.1.1"
+cabal_base_lib_depends="base mtl fgl directory hashable>=1.2&&<1.3 uhc-util>=0.1.1"
 if test x$enableClr = "xyes"
 then
   cabal_base_lib_depends="$cabal_base_lib_depends language-cil"

--- a/EHC/src/ehc/Base/HsName.chs
+++ b/EHC/src/ehc/Base/HsName.chs
@@ -213,8 +213,8 @@ hsnUniqifyEval = hsnUniqify HsNameUniqifier_Evaluated
 hsnHashWithSalt :: Int -> HsName -> Int
 hsnHashWithSalt salt (HsName_Base s      ) = hashWithSalt salt s
 hsnHashWithSalt salt (HsName_Pos  p      ) = hashWithSalt salt p
-hsnHashWithSalt salt (HsName_Modf _ q b u) = hashWithSalt salt q `combine` hashWithSalt salt b `combine` hashWithSalt salt (Map.toList u)
-hsnHashWithSalt salt (HNmNr i n          ) = i `combine` hashWithSalt salt n
+hsnHashWithSalt salt (HsName_Modf _ q b u) = hashWithSalt salt q `hashWithSalt` hashWithSalt salt b `hashWithSalt` hashWithSalt salt (Map.toList u)
+hsnHashWithSalt salt (HNmNr i n          ) = i `hashWithSalt` hashWithSalt salt n
 
 instance Hashable HsName where
   hashWithSalt salt n@(HsName_Modf h _ _ _) | h /= 0 = h
@@ -222,9 +222,9 @@ instance Hashable HsName where
 
 instance Hashable OrigName where
   hashWithSalt salt (OrigNone    ) = salt
-  hashWithSalt salt (OrigLocal  n) = 23 `combine` hashWithSalt salt n
-  hashWithSalt salt (OrigGlobal n) = 19 `combine` hashWithSalt salt n
-  hashWithSalt salt (OrigFunc   n) = 17 `combine` hashWithSalt salt n
+  hashWithSalt salt (OrigLocal  n) = 23 `hashWithSalt` hashWithSalt salt n
+  hashWithSalt salt (OrigGlobal n) = 19 `hashWithSalt` hashWithSalt salt n
+  hashWithSalt salt (OrigFunc   n) = 17 `hashWithSalt` hashWithSalt salt n
 
 instance Hashable HsNameUnique where
   hashWithSalt salt (HsNameUnique_None    ) = salt

--- a/EHC/src/ehc/Base/UID.chs
+++ b/EHC/src/ehc/Base/UID.chs
@@ -64,7 +64,7 @@ instance Show UID where
 
 %%[99
 instance Hashable UID where
-  hashWithSalt salt (UID h _) = salt `combine` h
+  hashWithSalt salt (UID h _) = salt `hashWithSalt` h
 %%]
 
 %%[1.UID.mkNewLevUID


### PR DESCRIPTION
'combine' is gone away, but hashWithSalt is a drop-in replacement.

Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
