### PR TITLE
Use bc-primitives for cr-target

### DIFF
--- a/EHC/ehclib/uhcbase/Data/Bits.hs
+++ b/EHC/ehclib/uhcbase/Data/Bits.hs
@@ -266,7 +266,7 @@ instance Bits Int where
     rotateR                = primRotateRightInt
 #if defined( __UHC_TARGET_JS__ )
     bitSize  _             = 31 -- for now...
-#elif defined( __UHC_TARGET_BC__ )
+#elif defined( __UHC_TARGET_BC__ ) || defined( __UHC_TARGET_CR__ )
     bitSize _              = SIZEOF_HSINT*8 - BITSIZEOF_WORDTAG
 #else
     bitSize _              = SIZEOF_HSINT*8

--- a/EHC/ehclib/uhcbase/UHC/Base.chs
+++ b/EHC/ehclib/uhcbase/UHC/Base.chs
@@ -976,7 +976,7 @@ foreign import prim primQuotInteger :: Integer -> Integer -> Integer
 foreign import prim primRemInteger  :: Integer -> Integer -> Integer
 #endif
 
-#if defined( __UHC_TARGET_BC__ ) || defined(__UHC_TARGET_JS__)
+#if defined( __UHC_TARGET_BC__ ) || defined(__UHC_TARGET_CR__) || defined(__UHC_TARGET_JS__)
 foreign import prim primQuotRemInteger       :: Integer -> Integer -> (Integer,Integer)
 foreign import prim primDivModInteger        :: Integer -> Integer -> (Integer,Integer)
 #endif

--- a/EHC/ehclib/uhcbase/include/HsBaseConfig.h.in
+++ b/EHC/ehclib/uhcbase/include/HsBaseConfig.h.in
@@ -303,7 +303,7 @@
 
 #ifdef __UHC_BUILDS_O__
 
-#if defined(__UHC_TARGET_BC__) || defined(__UHC_TARGET_C__)
+#if defined(__UHC_TARGET_BC__) || defined(__UHC_TARGET_CR__) || defined(__UHC_TARGET_C__)
 // # define HsBool				Word
 // # define HsInt				Word
 // # define HsWord64			Word64

--- a/EHC/ehclib/uhcbase/include/MachDeps.h.in
+++ b/EHC/ehclib/uhcbase/include/MachDeps.h.in
@@ -63,7 +63,7 @@
 #define USE_32_BITS 1
 #endif
 
-#ifdef __UHC_TARGET_BC__
+#if defined (__UHC_TARGET_BC__) || defined (__UHC_TARGET_CR__)
 #define BITSIZEOF_WORDTAG		1
 #else
 #define BITSIZEOF_WORDTAG		0


### PR DESCRIPTION
The ehclib is compiled to target=cr when doing a make install. This fails because of undefined primitives used in uhcbase.

I don't know if the ehclib should actually be compiled to target=cr in the first place. If it should, then I guess the proper solution would be to know the final code-gen target(bc,jazy,js,...) for which cr should be generated, but I think this is not available at the moment.
