### PR TITLE
Second half of Core API (CTags, Parsers, Pretty Printers)

### DIFF
--- a/EHC/src/ehc/API.chs
+++ b/EHC/src/ehc/API.chs
@@ -2,18 +2,23 @@
 module %%@{%{EH}%%}API
   (
     module %%@{%{EH}%%}Base.API
+
 %%[[(8 core)
   , module %%@{%{EH}%%}Core.API
 %%]]
+  , scan
   )
   where
 
 %%[[1
 import %%@{%{EH}%%}Base.API
+import %%@{%{EH}%%}Scanner.Machine
 %%]]
+
 
 %%[[(8 core)
 import %%@{%{EH}%%}Core.API
 %%]]
+
 
 %%]

--- a/EHC/src/ehc/AbstractCore.chs
+++ b/EHC/src/ehc/AbstractCore.chs
@@ -608,6 +608,7 @@ acoreTagTupTy :: (AbstractCore e m b bound boundmeta bcat mbind t p pr pf a) => 
 acoreTagTupTy tg t es = acoreTagTyTupBound tg t $ map acoreBound1Val es
 
 -- | Creates a new tuple/record with the given values.
+-- Has to be fully applied, partial application is not allowed.
 acoreTagTup :: (AbstractCore e m b bound boundmeta bcat mbind t p pr pf a) => CTag -> [e] -> e
 acoreTagTup tg es = acoreTagTupTy tg (acoreTyErr "acoreTupTy") es
 

--- a/EHC/src/ehc/Base/API.chs
+++ b/EHC/src/ehc/Base/API.chs
@@ -9,14 +9,14 @@ module %%@{%{EH}%%}Base.API
     EHCOpts
   , defaultEHCOpts
 
-  -- * Base types
-  -- | From Base.Common
+  -- * Constructor Tags
+  -- From Base.Common
   , CTag
 
-  -- | From Base.HsName
+  -- * Names
   , HsName
 
-  -- | From Base.HsName.Builtin
+  -- * Misc
 %%[[99
   , hsnEhcRunMain
 %%]]


### PR DESCRIPTION
Adds all the missing bits I needs for the Agda backend. Wasn't sure where to put the CTag things,
maybe this should be moved to Base/API.chs ?
