### PR TITLE
Fix target when compiled using aspects base only or running with Target_None

### DIFF
--- a/EHC/src/ehc/Base/Target.chs
+++ b/EHC/src/ehc/Base/Target.chs
@@ -156,7 +156,7 @@ supportedTargetMp :: Map.Map String Target
   where (ts,is) = unzip
           [ ((show t, t),(t,i))
           | (t,i)
-              <- []
+              <- [ mk Target_None [] ]
 %%[[(8 corebackend)
                  ++ [ mk Target_None_Core_AsIs [] ]
 %%]]


### PR DESCRIPTION
While trying to compile using `--with-aspects="base"` to get access to only the Parsers of UHC from the `UHC-Compiler` package I ran into the problem that no matter what I do, when I called `pAGItf` this would result in a `*** Exception: Prelude.foldr1: empty list` error being thrown.

After some investigating with GHCi's debugger I was able to find that the cause of this is that `pFFIWay` would fail because of the call to `pAnyKey` which is implemented using a foldr1.

The list that it is folding on is `allFFIWays` which is created from the map `allTargetInfoMp`.

When compiling with `--with-aspects="base"` this function is defined as:

```haskell
supportedTargetMp :: Map.Map String Target
(supportedTargetMp,allTargetInfoMp)
  = (Map.fromList ts, Map.fromList is)
  where (ts,is) = unzip
          [ ((show t, t),(t,i))
          | (t,i)
              <- []
          ]
        mk t ffis = (t,TargetInfo (FFIWay_Prim : ffis))
```
But the only `Target` available in this mode is `Target_None` which is also the `default` target. From the definition of `pFFIWay` and the fact that the default target is `Target_None` then most likely the default value shouldn't be `[]` but `[ mk Target_None [] ]`

This change successfully allows the parser to run.