### PR TITLE
Add travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,38 @@
+# NB: don't set `language: haskell` here
+
+# The following enables several GHC versions to be tested; often it's enough to test only against the last release in a major GHC version. Feel free to omit lines listings versions you don't need/want testing for.
+env:
+ - CABALVER=1.18 GHCVER=7.8.4
+ - CABALVER=1.22 GHCVER=7.10.1
+
+# Note: the distinction between `before_install` and `install` is not important.
+before_install:
+ - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
+ - travis_retry sudo apt-get update
+ - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER # see note about happy/alex
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+
+install:
+  - cabal --version
+  - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+  - travis_retry cabal update
+
+  - export PATH=$HOME/.cabal/bin:$PATH
+  # Showing Cabal configuration
+  - cat $HOME/.cabal/config
+  - cabal install -j -v2 happy
+  - cabal install -j -v2 uuagc uulib uhc-util network shuffle
+
+script:
+  - export INSTALL_DIR=$HOME/uhc-install/
+  - mkdir $INSTALL_DIR
+  - cd EHC
+  - ./configure --prefix $INSTALL_DIR
+  - make
+  - travis_wait make install
+  - $INSTALL_DIR/bin/uhc --version
+  # maybe we should run some tests here?
+
+matrix:
+  fast_finish: true
+


### PR DESCRIPTION
Adds a travis continous build. This will build all commits pushed to the UHC repository using GHC 7.8 and 7.10. An example build for my repository can be seen at:
https://travis-ci.org/phile314/uhc/builds/58264805

The actual build needs also to be enabled on the travis-ci.org website by toggling a switch, but this is easy to do once this is merged.